### PR TITLE
Resource names are aliases for claiming them

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 - In one window, run `VERIFICATION_TOKEN=abc123 PORT=8765 npm run dev-start` to start the server. In another window, run `./node_modules/.bin/lt --port 8765 --subdomain snag` to serve the app, so Slack can talk to it. For bonus points, run `npm run dev` to start watching files for linting and test running.
 
+- Update the URL to your `lt`-hosted domain under the "Integration Settings" on the [Slash Commands setup page](https://ownlocal.slack.com/services/119939919281). _Remember to switch it back to http://54.82.140.77:8765/slack/receive when you're finished._
+
 - When committing, pre-commit hooks must pass testing, package validation, and linting. To run these individually at any time:
   - `npm test`
   - `npm run lint`
@@ -22,3 +24,21 @@
 - `docker exec -it <container id> /bin/bash` to get into the image
 
 - `docker logs <container id>` to see app logs
+
+## Deploying
+
+0. Build the Docker image, a la `docker build -t snag --build-arg SNAG_TOKEN=abc123 .`.
+
+0. Confirm that the app runs, first by running the image [`npm run docker-serve`] and then by checking the logs within the running container.
+
+0. Be sure you have the AWS CLI tool installed.
+
+0. Upload the latest image to AWS's ECS by following the directions on their site, [accessible via the "View Push Commands" button](https://console.aws.amazon.com/ecs/home?region=us-east-1#/repositories/snag#images;tagStatus=ALL). _You can skip any steps related to locally building, since we did that earlier._
+
+0. After pushing the latest build of your Docker image to AWS's ECS, pop over to [Rancher](https://rancher.ownlocal.com).
+
+0. Go to the Stack for [`snag`](https://rancher.ownlocal.com/env/1a7/apps/stacks/1st12) and click the `upgrade` button all the way to the right [up arrow in a circle].
+
+0. On the next screen, click the "Upgrade" button at the bottom of the screen.
+
+0. When it's finished upgrading, the earlier up-arrow-in-a-circle will now be a checkmark-in-a-circle; click it to finish the upgrade process. And that's it!

--- a/index.js
+++ b/index.js
@@ -97,12 +97,26 @@ controller.on('slash_command', function (slashCommand, message) {
           queue.whois(resource.toLowerCase()));
       }
 
-      // // ***** `resource`: alias for claiming a resource *****
+      // ***** `resource`: alias for claiming a resource *****
       if (queue.store[message.text]) {
-        slashCommand.replyPrivate(
-          message,
-          queue.claim(message.text, message.user_name)
-        );
+        // Release the resource that the user already claimed
+        if (queue.hasResource(
+          queue.store, message.username, queue.store[message.text]
+        )) {
+          slashCommand.replyPrivate(
+            message,
+            queue.release(
+              message.user_name, queue.store[message.text].toLowerCase()
+            )
+          );
+
+        // Claim the unclaimed resource
+        } else {
+          slashCommand.replyPrivate(
+            message,
+            queue.claim(message.text, message.user_name)
+          );
+        }
       }
 
       break;

--- a/index.js
+++ b/index.js
@@ -97,6 +97,14 @@ controller.on('slash_command', function (slashCommand, message) {
           queue.whois(resource));
       }
 
+      // // ***** `resource`: alias for claiming a resource *****
+      if (queue.store[message.text]) {
+        slashCommand.replyPrivate(
+          message,
+          queue.claim(message.text, message.user_name)
+        );
+      }
+
       break;
     default:
       slashCommand.replyPublic(message, 'I\'m afraid I don\'t know how to ' + message.command + ' yet.');

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -84,6 +84,10 @@ function inStore (store, resource) {
   return _.has(store, resource);
 }
 
+function hasResource (store, username, resource) {
+  return true;
+}
+
 function assignResource (store, username, resource) {
   // Happy path
   if (inStore(store, resource) && !store[resource]) {
@@ -134,18 +138,19 @@ function prettyify (str) {
 }
 
 module.exports = {
-  assignResource: assignResource,
-  inStore: inStore,
-  prettyify: prettyify,
-  releaseResource: releaseResource,
-  resetStore: resetStore,
+  hasResource,
+  assignResource,
+  inStore,
+  prettyify,
+  releaseResource,
+  resetStore,
 
-  all: all,
-  claim: claim,
-  helpText: helpText,
-  listQueues: listQueues,
-  release: release,
-  whois: whois,
+  all,
+  claim,
+  helpText,
+  listQueues,
+  release,
+  whois,
 
-  store: store
+  store
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -85,7 +85,10 @@ function inStore (store, resource) {
 }
 
 function hasResource (store, username, resource) {
-  return true;
+  if (store[resource] === username) {
+    return true;
+  }
+  return false;
 }
 
 function assignResource (store, username, resource) {

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -107,6 +107,13 @@ test('List all claimed resources', (t) => {
   t.is(queue.all(), 'AF Prod: X\n');
 });
 
+test('Checks is a user has claimed a resource', (t) => {
+  const username = 'X';
+  const resource = 'af-prod';
+
+  t.is(queue.hasResource(username, resource), true);
+});
+
 // test('test', (t) => {
 //   t.is(test(), expectedResult);
 // });

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -107,13 +107,18 @@ test('List all claimed resources', (t) => {
   t.is(queue.all(), 'AF Prod: X\n');
 });
 
-test('Checks is a user has claimed a resource', (t) => {
+test('A user has claimed a resource', (t) => {
   const username = 'X';
   const resource = 'af-prod';
+  const store = {'af-prod': username};
 
-  t.is(queue.hasResource(username, resource), true);
+  t.is(queue.hasResource(store, username, resource), true);
 });
 
-// test('test', (t) => {
-//   t.is(test(), expectedResult);
-// });
+test('A user has not claimed a resource', (t) => {
+  const username = 'X';
+  const resource = 'af-prod';
+  const store = {'af-prod': 'Y'};
+
+  t.is(queue.hasResource(store, username, resource), false);
+});


### PR DESCRIPTION
Aliases commands like `/snaggg af-prod` to the claim command `/snaggg claim af-prod`. Thinking we can also have it alias to `/snaggg release af-prod` if the resource is already claimed by the user.

The workflow is currently `/snaggg claim af-prod` then `/snaggg release af-prod`.
It could possibly be `/snaggg af-prod` then `/snaggg af-prod`.

### Notes
Wanted to write a test for this but it looks like the code would have to be refactored to be more easily testable.

I started down that path but didn't want to go through the trouble of messing with the bot locally so I decided to put this up and see what you thought.